### PR TITLE
Change formattingLongAsNumber to 'val' in order to use in JsonFormat

### DIFF
--- a/core/shared/src/main/scala/scalapb_circe/JsonFormat.scala
+++ b/core/shared/src/main/scala/scalapb_circe/JsonFormat.scala
@@ -61,7 +61,7 @@ case class FormatRegistry(
 class Printer(
   includingDefaultValueFields: Boolean = false,
   preservingProtoFieldNames: Boolean = false,
-  formattingLongAsNumber: Boolean = false,
+  val formattingLongAsNumber: Boolean = false,
   formattingEnumsAsNumber: Boolean = false,
   formatRegistry: FormatRegistry = JsonFormat.DefaultRegistry,
   val typeRegistry: TypeRegistry = TypeRegistry.empty
@@ -402,7 +402,12 @@ object JsonFormat {
     implicit cmp: GeneratedMessageCompanion[T]
   ): ((Printer, T) => Json) = {
     val fieldDesc = cmp.scalaDescriptor.findFieldByNumber(1).get
-    (printer, t) => printer.serializeSingleValue(fieldDesc, t.getField(fieldDesc), formattingLongAsNumber = false)
+    (printer, t) =>
+      printer.serializeSingleValue(
+        fieldDesc,
+        t.getField(fieldDesc),
+        formattingLongAsNumber = printer.formattingLongAsNumber
+      )
   }
 
   def primitiveWrapperParser[T <: GeneratedMessage with Message[T]](

--- a/core/shared/src/test/scala/scalapb_circe/PrimitiveWrappersSpec.scala
+++ b/core/shared/src/test/scala/scalapb_circe/PrimitiveWrappersSpec.scala
@@ -30,6 +30,12 @@ class PrimitiveWrappersSpec extends FlatSpec with MustMatchers {
       render(Map("wBytes" -> Json.fromString("AwUE")))
     )
     JsonFormat.toJson(Wrapper(wBytes = Some(ByteString.EMPTY))) must be(render(Map("wBytes" -> Json.fromString(""))))
+    new Printer(formattingLongAsNumber = true).toJson(Wrapper(wUint64 = Some(125))) must be(
+      render(Map("wUint64" -> Json.fromLong(125)))
+    )
+    new Printer(formattingLongAsNumber = true).toJson(Wrapper(wInt64 = Some(125))) must be(
+      render(Map("wInt64" -> Json.fromLong(125)))
+    )
   }
 
   "primitive values" should "parse properly" in {


### PR DESCRIPTION
When a long wrapper type is defined in Protocol buffer, the printer generates an optional long value as String type even though `formattingLongAsNumber` is true. I hope this PR will be helpful to solve this small problem if this behavior is not expected:)  