### PR TITLE
Fixed getting enum from value by index in implicit

### DIFF
--- a/core/shared/src/main/scala/scalapb_circe/codec.scala
+++ b/core/shared/src/main/scala/scalapb_circe/codec.scala
@@ -53,7 +53,7 @@ object codec {
     (c: HCursor) => {
       val companion = implicitly[GeneratedEnumCompanion[E]]
       Try(p.defaultEnumParser(companion.scalaDescriptor, c.value)) match {
-        case Success(e) => Right(companion.fromValue(e.index))
+        case Success(e) => Right(companion.fromValue(e.number))
         case Failure(t) => Left(DecodingFailure(t.getMessage, List.empty))
       }
     }

--- a/core/shared/src/test/protobuf/test.proto
+++ b/core/shared/src/test/protobuf/test.proto
@@ -9,6 +9,7 @@ enum MyEnum {
   UNKNOWN = 0;
   V1 = 1;
   V2 = 2;
+  V3 = 4;
 }
 
 message MyTest {

--- a/core/shared/src/test/protobuf/test3.proto
+++ b/core/shared/src/test/protobuf/test3.proto
@@ -12,6 +12,7 @@ message MyTest3 {
     UNKNOWN = 0;
     V1 = 1;
     V2 = 2;
+    V3 = 4;
   }
 
   string s = 1;

--- a/core/shared/src/test/scala/scalapb_circe/CodecSpec.scala
+++ b/core/shared/src/test/scala/scalapb_circe/CodecSpec.scala
@@ -108,7 +108,7 @@ class CodecSpec extends AnyFreeSpec with Matchers {
         val decodedWithJsonFormat = cmp.fromValue(
           JsonFormat.parser
             .defaultEnumParser(cmp.scalaDescriptor, JsonFormat.printer.serializeEnum(e.scalaValueDescriptor))
-            .index
+            .number
         )
         val decodedImplicitly = e.asJson.as[E]
         decodedImplicitly mustBe Right(decodedWithJsonFormat)


### PR DESCRIPTION
In case when number is omitted in enum proto implicit parser decodes value incorrectly by index.
For example:
```
enum MyEnum {
  UNKNOWN = 0;
  V1 = 1;
  V2 = 2;
  V3 = 4;
}
```

code:
```
MyEnum.V3.asJson.as[MyEnum]
```
results:
```
V2
```
but expected:
```
V3
```
